### PR TITLE
Replace last use of "vars" with "our"

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -10,7 +10,6 @@ name=App-instopt
 [Prereqs]
 perl=5.010001
 strict=0
-vars=0
 warnings=0
 App::swcat=0.015
 Archive::Any=0

--- a/lib/App/instopt.pm
+++ b/lib/App/instopt.pm
@@ -17,7 +17,7 @@ use Perinci::Object;
 use PerlX::Maybe;
 use Sah::Schema::software::arch;
 
-use vars '%Config';
+our %Config;
 our %SPEC;
 
 our @all_known_archs = @{ $Sah::Schema::software::arch::schema->[1]{in} };


### PR DESCRIPTION
Use of this pragma is discouraged in favour of "our" under 5.06+.

This dist depends on 5.10+ and already uses "our" elsewhere.