### PR TITLE
Add a general 'list' subcommand with filters

### DIFF
--- a/script/instopt
+++ b/script/instopt
@@ -27,6 +27,7 @@ my $cli = Perinci::CmdLine::Any->new(
     url => $prefix,
     log => 1,
     subcommands => {
+        'list'                     => {url=>"${prefix}list"},
         'list-installed'           => {url=>"${prefix}list_installed"},
         'list-installed-versions'  => {url=>"${prefix}list_installed_versions"},
         'list-downloaded'          => {url=>"${prefix}list_downloaded"},


### PR DESCRIPTION
As per discussion in https://github.com/lianasmelati/perl-App-instopt/pull/2,
I'm adding a general 'list' subcommand with filters. 'list-installed' and
'list-downloaded' are now implemented in terms of 'list'.